### PR TITLE
Improve demo UX

### DIFF
--- a/recallme/README.md
+++ b/recallme/README.md
@@ -51,9 +51,17 @@ produits rappelés détectés dans vos achats.
     ```
     Vous pouvez également lancer le script depuis n'importe quel dossier en
     indiquant son chemin complet ; il s'adaptera automatiquement.
-    Une fois le serveur lancé, ouvrez `http://localhost:5000` dans votre navigateur
-    pour voir vos achats. Les lignes en rouge indiquent les produits rappelés. Le
-    site affiche également les 20 derniers rappels connus.
+    Une fois le serveur lancé, ouvrez `http://localhost:5000` dans votre navigateur.
+    Par défaut aucune liste d'achats n'est affichée : cliquez sur le bouton
+    **Essayer la démo** pour générer un exemple de courses. Les lignes en rouge
+    indiquent les produits rappelés. Le site affiche également les 20 derniers
+    rappels connus.
+
+    Un bouton "Essayer la démo" permet de générer aléatoirement une liste
+    d'achats (20 articles par défaut) à partir du fichier
+    `french_top500_products.csv`. Cette liste inclut entre 0 et 3 produits
+    rappelés pour visualiser le fonctionnement. Vous pouvez ajuster le nombre
+    d'articles en passant `n=40` ou tout autre chiffre dans l'URL `/demo`.
 
     Cette interface web utilise un petit gabarit HTML et la librairie Bootstrap
     pour offrir un aperçu plus attrayant de vos données.

--- a/recallme/app.py
+++ b/recallme/app.py
@@ -1,13 +1,17 @@
-from flask import Flask, render_template
+from flask import Flask, render_template, request
 
 try:  # Support execution with `python app.py`
-    from .main import load_recalls, load_purchases  # type: ignore
+    from .main import (
+        load_recalls,
+        load_purchases,
+        generate_demo_purchases,
+    )  # type: ignore
 except ImportError:  # pragma: no cover - fallback for direct script execution
     import sys
     from pathlib import Path
 
     sys.path.append(str(Path(__file__).resolve().parent))
-    from main import load_recalls, load_purchases
+    from main import load_recalls, load_purchases, generate_demo_purchases
 
 def merge_data():
     recalls = load_recalls()
@@ -27,12 +31,40 @@ def merge_data():
         )
     return results, recalls
 
+
+def merge_demo_data(num_items=20):
+    recalls = load_recalls()
+    purchases = generate_demo_purchases(recalls, num_items=num_items)
+    results = []
+    for _, row in purchases.iterrows():
+        recalled = any(
+            rec["name"] == row["name"] and rec["brand"] == row["brand"]
+            for rec in recalls
+        )
+        results.append(
+            {
+                "name": row["name"],
+                "brand": row["brand"],
+                "recalled": recalled,
+            }
+        )
+    return results, recalls
+
 app = Flask(__name__)
 
 @app.route("/")
 def index():
-    results, recalls = merge_data()
+    recalls = load_recalls()
+    # No purchase list by default; users can try the demo instead
+    return render_template("index.html", results=[], recalls=recalls)
+
+
+@app.route("/demo")
+def demo():
+    num = int(request.args.get("n", 20))
+    results, recalls = merge_demo_data(num)
     return render_template("index.html", results=results, recalls=recalls)
 
 if __name__ == "__main__":
     app.run(debug=True, host="0.0.0.0")
+

--- a/recallme/main.py
+++ b/recallme/main.py
@@ -1,4 +1,5 @@
 import json
+import random
 from pathlib import Path
 
 import pandas as pd
@@ -44,6 +45,27 @@ def load_purchases(path="purchases.csv"):
     file_path = BASE_DIR / path
     # On spécifie le type des colonnes pour éviter les erreurs de comparaison
     return pd.read_csv(file_path, dtype={'name': 'string', 'brand': 'string'})
+
+
+def generate_demo_purchases(
+    recalls,
+    path="french_top500_products.csv",
+    num_items=20,
+    max_recalled=3,
+):
+    """Generate a random shopping list including a few recalled products."""
+    data_path = BASE_DIR / path
+    df = pd.read_csv(data_path)
+    purchases = df.sample(n=num_items)[["ProductName", "Brand"]]
+    purchases.rename(columns={"ProductName": "name", "Brand": "brand"}, inplace=True)
+
+    recall_count = random.randint(0, max_recalled)
+    if recall_count:
+        recall_sample = random.sample(recalls, k=recall_count)
+        recall_df = pd.DataFrame(recall_sample)
+        purchases = pd.concat([purchases, recall_df], ignore_index=True)
+
+    return purchases.sample(frac=1).reset_index(drop=True)
 
 
 def check_recalls(recalls, purchases):

--- a/recallme/static/style.css
+++ b/recallme/static/style.css
@@ -4,3 +4,7 @@ body {
 .table-danger {
     background-color: #f8d7da;
 }
+
+.alert-info {
+    font-size: 1.2rem;
+}

--- a/recallme/templates/index.html
+++ b/recallme/templates/index.html
@@ -8,7 +8,10 @@
 </head>
 <body>
 <div class="container py-4">
-    <h1 class="mb-4">Historique d'achats</h1>
+    <div class="d-flex justify-content-between align-items-center mb-4">
+        <h1 class="mb-0">RecallMe</h1>
+        <a href="{{ url_for('demo') }}" class="btn btn-primary btn-lg">Essayer la démo</a>
+    </div>
     {% if results %}
     <table class="table table-striped">
         <thead>
@@ -49,7 +52,9 @@
         </tbody>
     </table>
     {% else %}
-    <p>Aucun achat disponible.</p>
+    <div class="alert alert-info text-center" role="alert">
+        Aucun achat disponible. Cliquez sur <strong>Essayer la démo</strong> pour voir un exemple.
+    </div>
     {% endif %}
 </div>
 </body>


### PR DESCRIPTION
## Summary
- start homepage empty and encourage demo
- enhance the demo button styling
- show an info alert when there are no purchases
- tweak demo instructions in README

## Testing
- `pip install -q -r recallme/requirements.txt`
- `python -m compileall -q recallme`
- `python -m recallme.main`
- `python -m recallme.app` *(server started then was manually stopped)*

------
https://chatgpt.com/codex/tasks/task_e_685173a87afc8322943fc670e1def535