### PR TITLE
Fix demo fallback

### DIFF
--- a/recallme/main.py
+++ b/recallme/main.py
@@ -111,26 +111,6 @@ def generate_demo_purchases(
     return purchases.sample(frac=1).reset_index(drop=True)
 
 
-def generate_demo_purchases(
-    recalls,
-    path="french_top500_products.csv",
-    num_items=20,
-    max_recalled=3,
-):
-    """Generate a random shopping list including a few recalled products."""
-    data_path = BASE_DIR / path
-    df = pd.read_csv(data_path)
-    purchases = df.sample(n=num_items)[["ProductName", "Brand"]]
-    purchases.rename(columns={"ProductName": "name", "Brand": "brand"}, inplace=True)
-
-    recall_count = random.randint(0, max_recalled)
-    if recall_count:
-        recall_sample = random.sample(recalls, k=recall_count)
-        recall_df = pd.DataFrame(recall_sample)
-        purchases = pd.concat([purchases, recall_df], ignore_index=True)
-
-    return purchases.sample(frac=1).reset_index(drop=True)
-
 
 def check_recalls(recalls, purchases):
     """Vérifie si des produits achetés correspondent à des rappels."""


### PR DESCRIPTION
## Summary
- remove duplicate `generate_demo_purchases` definition so fallback works

## Testing
- `pytest -q`
- `python -m recallme.app` then `curl http://127.0.0.1:5000/demo | head`

------
https://chatgpt.com/codex/tasks/task_e_68525cc7412083229bc22e79deb05979