### PR TITLE
Add forced API mode for demo

### DIFF
--- a/recallme/README.md
+++ b/recallme/README.md
@@ -3,9 +3,10 @@
 Ceci est une démonstration simplifiée de l'application **RecallMe**. L'idée est de montrer comment croiser une liste de rappels produits avec vos achats.
 
 Le script `main.py` récupère la liste des rappels depuis l'API officielle
-RappelConso (avec repli sur un fichier local en cas d'échec de connexion) puis
-charge vos achats depuis `purchases.csv` afin d'afficher les produits
-concernés. Les rappels proviennent de l'URL suivante :
+RappelConso. Par défaut il bascule sur un fichier local si la connexion échoue,
+mais vous pouvez **désactiver ce repli** et forcer autant de tentatives que
+nécessaire en appelant ``load_recalls(require_api=True, retries=None)``.
+Les rappels proviennent de l'URL suivante :
 
 https://data.economie.gouv.fr/api/explore/v2.1/catalog/datasets/rappelconso-v2-gtin-trie/records?limit=20
 
@@ -24,7 +25,9 @@ https://data.economie.gouv.fr/api/explore/v2.1/catalog/datasets/rappelconso-v2-g
     comparer vos achats avec ces rappels. Il tente automatiquement de récupérer
     les rappels depuis l'API officielle RappelConso et revient aux données
     locales en cas d'échec. En cas d'erreur réseau, un message indique que les
-    données locales sont utilisées.
+    données locales sont utilisées. Pour exiger absolument les données de
+    l'API, utilisez ``load_recalls(require_api=True, retries=None)`` afin de
+    réessayer indéfiniment jusqu'au succès.
 
 3.  Ouvrir l'interface graphique (facultatif) :
     ```bash
@@ -59,9 +62,10 @@ produits rappelés détectés dans vos achats.
 
     Un bouton "Essayer la démo" permet de générer aléatoirement une liste
     d'achats (20 articles par défaut) à partir du fichier
-    `french_top500_products.csv`. Cette liste inclut entre 0 et 3 produits
-    rappelés pour visualiser le fonctionnement. Vous pouvez ajuster le nombre
-    d'articles en passant `n=40` ou tout autre chiffre dans l'URL `/demo`.
+    `french_top500_products.csv`. Un à trois produits rappelés peuvent y être
+    insérés aléatoirement, mais il est également possible qu'aucun rappel ne
+    soit présent. Vous pouvez ajuster le nombre d'articles en passant `n=40`
+    ou tout autre chiffre dans l'URL `/demo`.
 
     Les fichiers `french_top500_products.csv` et `sample_recalls.json` sont
     fournis dans le dépôt. S'ils sont manquants, l'application tentera de les

--- a/recallme/app.py
+++ b/recallme/app.py
@@ -17,7 +17,7 @@ except ImportError:  # pragma: no cover - fallback for direct script execution
     from main import load_recalls, load_purchases, generate_demo_purchases
 
 def merge_data():
-    recalls = load_recalls()
+    recalls = load_recalls(require_api=True, retries=None)
     purchases = load_purchases()
     results = []
     for _, row in purchases.iterrows():
@@ -36,7 +36,7 @@ def merge_data():
 
 
 def merge_demo_data(num_items=20):
-    recalls = load_recalls()
+    recalls = load_recalls(require_api=True, retries=None)
     purchases = generate_demo_purchases(recalls, num_items=num_items)
     results = []
     for _, row in purchases.iterrows():
@@ -57,7 +57,7 @@ app = Flask(__name__)
 
 @app.route("/")
 def index():
-    recalls = load_recalls()
+    recalls = load_recalls(require_api=True, retries=None)
     logo_exists = (STATIC_DIR / "logo.png").exists()
     # No purchase list by default; users can try the demo instead
     return render_template("index.html", results=[], recalls=recalls, logo_exists=logo_exists)

--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -1,0 +1,37 @@
+import random
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from recallme.main import generate_demo_purchases
+
+SAMPLE_RECALLS = [
+    {"name": "Lait entier 1L", "brand": "MarqueX"},
+    {"name": "Yaourt nature", "brand": "DairyBest"},
+]
+
+def test_demo_can_exclude_recall(tmp_path, monkeypatch):
+    csv = tmp_path / "products.csv"
+    df = pd.DataFrame({"ProductName": ["Baguette"], "Brand": ["Boulangerie"]})
+    df.to_csv(csv, index=False)
+
+    monkeypatch.setattr(random, "randint", lambda a, b: 0)
+
+    purchases = generate_demo_purchases(SAMPLE_RECALLS, path=str(csv), num_items=1)
+    recalled = [p for p in purchases.to_dict(orient="records") if p in SAMPLE_RECALLS]
+    assert not recalled
+
+
+def test_demo_includes_recall_when_requested(tmp_path, monkeypatch):
+    csv = tmp_path / "products.csv"
+    df = pd.DataFrame({"ProductName": ["Baguette"], "Brand": ["Boulangerie"]})
+    df.to_csv(csv, index=False)
+
+    monkeypatch.setattr(random, "randint", lambda a, b: 2)
+    monkeypatch.setattr(random, "sample", lambda seq, k: seq[:k])
+
+    purchases = generate_demo_purchases(SAMPLE_RECALLS, path=str(csv), num_items=1)
+    recalled = [p for p in purchases.to_dict(orient="records") if p in SAMPLE_RECALLS]
+    assert len(recalled) == 2

--- a/tests/test_load_recalls.py
+++ b/tests/test_load_recalls.py
@@ -1,0 +1,50 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from recallme.main import load_recalls
+
+class DummyResponse:
+    def __init__(self, data, status=200):
+        self._data = data
+        self.status_code = status
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise Exception("HTTP error")
+
+    def json(self):
+        return self._data
+
+
+def test_load_recalls_requires_api_failure(monkeypatch):
+    def fail_get(*args, **kwargs):
+        raise ConnectionError("no network")
+    monkeypatch.setattr("requests.get", fail_get)
+    with pytest.raises(RuntimeError):
+        load_recalls(require_api=True, retries=1)
+
+
+def test_load_recalls_success(monkeypatch):
+    data = {"results": [{"libelle_commercial": "Produit", "marque_produit": "X"}]}
+    monkeypatch.setattr("requests.get", lambda *a, **k: DummyResponse(data))
+    recalls = load_recalls(require_api=True, retries=1)
+    assert recalls == [{"name": "Produit", "brand": "X"}]
+
+
+def test_load_recalls_retry_until_success(monkeypatch):
+    data = {"results": [{"libelle_commercial": "Produit", "marque_produit": "X"}]}
+    calls = {"n": 0}
+
+    def flakey_get(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise ConnectionError("fail")
+        return DummyResponse(data)
+
+    monkeypatch.setattr("requests.get", flakey_get)
+    recalls = load_recalls(require_api=True, retries=None)
+    assert calls["n"] == 3
+    assert recalls == [{"name": "Produit", "brand": "X"}]


### PR DESCRIPTION
## Summary
- always call RappelConso with `require_api=True` in the web app
- allow zero recalled products again when generating demo purchases
- clarify README about endless API retries and random recalls
- expand tests for demo purchase randomness and infinite retries

## Testing
- `pytest -q`
- `curl -I https://data.economie.gouv.fr/api/explore/v2.1/catalog/datasets/rappelconso-v2-gtin-trie/records?limit=1`

------
https://chatgpt.com/codex/tasks/task_e_68525cc7412083229bc22e79deb05979