### PR TITLE
Add API test script

### DIFF
--- a/recallme/README.md
+++ b/recallme/README.md
@@ -97,4 +97,11 @@ Vous devriez voir la liste des produits achetés faisant l'objet d'un rappel san
 Si l'application reste bloquée en attendant la réponse de l'API, commencez par vérifier la connectivité :
 
 ```bash
-curl "[https://data.economie.gouv.fr/api/explore/v2.1/catalog/datasets/rappelconso-v2-gtin-trie/records?limit=1](https://data.economie.gouv.fr/api/explore/v2.1/catalog/datasets/rappelconso-v2-gtin-trie/records?limit=1)" -H "Accept: application/json"
+curl "https://data.economie.gouv.fr/api/explore/v2.1/catalog/datasets/rappelconso-v2-gtin-trie/records?limit=1" -H "Accept: application/json"
+```
+
+Cette commande doit renvoyer un petit document JSON. Vous pouvez également tester l'appel directement depuis Python :
+
+```bash
+python -m recallme.check_api
+```

--- a/recallme/app.py
+++ b/recallme/app.py
@@ -1,4 +1,4 @@
-from Flask import Flask, render_template, request
+from flask import Flask, render_template, request
 from pathlib import Path
 
 BASE_DIR = Path(__file__).resolve().parent

--- a/recallme/check_api.py
+++ b/recallme/check_api.py
@@ -1,0 +1,32 @@
+import requests
+
+API_PATH = "/api/explore/v2.1/catalog/datasets/rappelconso-v2-gtin-trie/records"
+API_URL = f"https://data.economie.gouv.fr{API_PATH}"
+
+
+def check_api(limit: int = 5) -> None:
+    """Fetch sample data from the RappelConso API and print the result."""
+    print("Requesting", API_URL)
+    resp = requests.get(
+        API_URL,
+        params={"limit": limit},
+        headers={"Accept": "application/json"},
+        timeout=10,
+    )
+    print("Status:", resp.status_code)
+    try:
+        data = resp.json()
+    except ValueError:
+        print("Response was not JSON:")
+        print(resp.text[:200])
+        return
+    results = data.get("results", [])
+    print(f"Received {len(results)} results")
+    if results:
+        print("First result:", results[0])
+    else:
+        print("No data returned")
+
+
+if __name__ == "__main__":
+    check_api()

--- a/recallme/main.py
+++ b/recallme/main.py
@@ -61,6 +61,7 @@ def load_recalls(
             response = requests.get(
                 API_URL,
                 params={"limit": limit},
+                headers={"Accept": "application/json"},
                 timeout=10,
             )
             print("Status:", response.status_code)


### PR DESCRIPTION
## Summary
- add a `check_api.py` helper to manually query RappelConso
- send `Accept: application/json` header in `load_recalls`
- document API checks in the README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685289fa4034832293baf88c5a0b537e