### PR TITLE
Fix API URLs in code

### DIFF
--- a/recallme/README.md
+++ b/recallme/README.md
@@ -105,7 +105,6 @@ Vous devriez voir la liste des produits achetés faisant l'objet d'un rappel san
 Si l'application reste bloquée en attendant la réponse de l'API, commencez par vérifier la connectivité :
 
 ```bash
-<<<<<<< aswyud-codex/corriger-erreur-module-flask-non-trouvé
 curl "https://data.economie.gouv.fr/api/explore/v2.1/catalog/datasets/rappelconso-v2-gtin-trie/records?limit=1&order_by=date_publication%20desc" -H "Accept: application/json"
 ```
 
@@ -123,6 +122,12 @@ Vous pouvez réessayer en ignorant les variables `HTTP(S)_PROXY` (avec
 ```bash
 python -m recallme.check_api --no-proxy
 ```
-=======
-curl "[https://data.economie.gouv.fr/api/explore/v2.1/catalog/datasets/rappelconso-v2-gtin-trie/records?limit=1&order_by=date_publication%20desc](https://data.economie.gouv.fr/api/explore/v2.1/catalog/datasets/rappelconso-v2-gtin-trie/records?limit=1&order_by=date_publication%20desc)" -H "Accept: application/json"
->>>>>>> main
+
+Si à l'inverse l'appel n'aboutit que lorsque vous passez par votre
+proxy d'entreprise, assurez‑vous que les variables d'environnement
+`HTTP_PROXY` ou `HTTPS_PROXY` sont correctement renseignées. Vous
+pouvez également forcer explicitement leur utilisation :
+
+```bash
+python -m recallme.check_api --use-proxy
+```

--- a/recallme/check_api.py
+++ b/recallme/check_api.py
@@ -3,7 +3,7 @@ import requests
 import argparse
 
 API_PATH = "/api/explore/v2.1/catalog/datasets/rappelconso-v2-gtin-trie/records"
-API_URL = f"[https://data.economie.gouv.fr](https://data.economie.gouv.fr){API_PATH}"
+API_URL = f"https://data.economie.gouv.fr{API_PATH}"
 
 
 def check_api(limit: int = 5, *, use_proxy: bool | None = None) -> None:

--- a/recallme/main.py
+++ b/recallme/main.py
@@ -10,7 +10,7 @@ import requests
 BASE_DIR = Path(__file__).resolve().parent
 
 API_PATH = "/api/explore/v2.1/catalog/datasets/rappelconso-v2-gtin-trie/records"
-API_URL = f"[https://data.economie.gouv.fr](https://data.economie.gouv.fr){API_PATH}"
+API_URL = f"https://data.economie.gouv.fr{API_PATH}"
 
 FALLBACK_RECALLS = [
     {"name": "Lait entier 1L", "brand": "MarqueX"},
@@ -111,7 +111,7 @@ def load_recalls(
                 with file_path.open("r", encoding="utf-8") as f:
                     return json.load(f)
             url = (
-                "[https://raw.githubusercontent.com/bobthecomputer/recallme/main/](https://raw.githubusercontent.com/bobthecomputer/recallme/main/)"
+                "https://raw.githubusercontent.com/bobthecomputer/recallme/main/"
                 f"recallme/{path}"
             )
             if _download_file(url, file_path):
@@ -137,7 +137,7 @@ def generate_demo_purchases(
     data_path = BASE_DIR / path
     if not data_path.exists():
         url = (
-            "[https://raw.githubusercontent.com/bobthecomputer/recallme/main/](https://raw.githubusercontent.com/bobthecomputer/recallme/main/)"
+            "https://raw.githubusercontent.com/bobthecomputer/recallme/main/"
             f"recallme/{path}"
         )
         if not _download_file(url, data_path):


### PR DESCRIPTION
## Summary
- correct RappelConso API URL in `check_api.py` and `main.py`
- fix fallback download URLs in `main.py`

## Testing
- `pip install -r recallme/requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6852d19294d08322a0c4e31eb7655e05